### PR TITLE
Move seed warning as it was triggering incorrectly

### DIFF
--- a/src/nhssynth/cli/config.py
+++ b/src/nhssynth/cli/config.py
@@ -114,6 +114,8 @@ def read_config(
     ), f"Required arguments are missing from the passed config file: {[ra['module'] + ':' + ra['arg'] for ra in required_args if not getattr(new_args, ra['arg'])]}"
 
     # Run the appropriate execution function(s)
+    if not new_args.seed:
+        warnings.warn("No seed has been specified, meaning the results of this run may not be reproducible.")
     new_args.modules_to_run = modules_to_run
     new_args.module_handover = {}
     for module in new_args.modules_to_run:

--- a/src/nhssynth/cli/run.py
+++ b/src/nhssynth/cli/run.py
@@ -22,12 +22,11 @@ def run() -> None:
 
     args = parser.parse_args()
 
-    if not args.seed:
-        warnings.warn("No seed has been specified, meaning the results of this run may not be reproducible.")
-
     # Use get to return None when no function has been set, i.e. user made no running choice
     executor = vars(args).get("func")
     if executor:
+        if not args.seed:
+            warnings.warn("No seed has been specified, meaning the results of this run may not be reproducible.")
         args.modules_to_run = get_modules_to_run(executor)
         args.module_handover = {}
         executor(args)


### PR DESCRIPTION
The check for a seed being set was happening before config files were being read, meaning it would trigger incorrectly. This has now been fixed.