### PR TITLE
Improving the Python API

### DIFF
--- a/src/nhssynth/modules/dataloader/metadata.py
+++ b/src/nhssynth/modules/dataloader/metadata.py
@@ -159,7 +159,8 @@ class MetaData:
         return iter(self._metadata.values())
 
     @classmethod
-    def load(cls, path: str, data: pd.DataFrame):
+    def load(cls, path_str: str, data: pd.DataFrame):
+        path = pathlib.Path(path_str)
         if path.exists():
             with open(path) as stream:
                 metadata = yaml.safe_load(stream)

--- a/src/nhssynth/modules/dataloader/metatransformer.py
+++ b/src/nhssynth/modules/dataloader/metatransformer.py
@@ -200,7 +200,7 @@ class MetaTransformer:
 
         return pd.concat(transformed_columns, axis=1)
 
-    def apply(self) -> None:
+    def apply(self) -> pd.DataFrame:
         """
         Applies the various steps of the MetaTransformer to a passed DataFrame.
 
@@ -213,6 +213,7 @@ class MetaTransformer:
         self.typed_dataset = self.apply_dtypes()
         self.prepared_dataset = self.apply_missingness_strategy()
         self.transformed_dataset = self.transform()
+        return self.transformed_dataset
 
     def get_typed_dataset(self) -> pd.DataFrame:
         if not hasattr(self, "typed_dataset"):

--- a/src/nhssynth/modules/model/models/VAE.py
+++ b/src/nhssynth/modules/model/models/VAE.py
@@ -190,7 +190,10 @@ class VAE(Model):
         ) * torch.randn_like(x_gen[:, self.single_column_indices])
         if torch.cuda.is_available():
             x_gen_ = x_gen_.cpu()
-        return pd.DataFrame(x_gen_.detach(), columns=self.columns)
+        data = pd.DataFrame(x_gen_.detach(), columns=self.columns)
+        if self.has_metatransformer:
+            data = self.metatransformer.inverse_apply(data)
+        return data
 
     def loss(self, X):
         mu_z, logsigma_z = self.encoder(X)


### PR DESCRIPTION
We are currently at:

```python
# should be easy to clean these up at some point, not important
from nhssynth.modules.dataloader.metatransformer import MetaTransformer
from nhssynth.modules.model.models import DPVAE

import pandas as pd

data = pd.read_csv("data/support.csv")
# This step is technically optional, we could instead do MetaTransformer(df) but then it will auto-generate metadata (which is imperfect)
mt = MetaTransformer.from_path(data, "data/support_metadata.yaml")
prepared_data = mt.apply()

# It makes far more sense (in my opinion) to instantiate the model with the data, as this determines the structure of the instantiated object + the thing we want to save etc.
model = DPVAE.from_metatransformer(prepared_data, mt)
results = model.train()

synthetic_data = model.generate(1000)
```

This is not exactly what #27 set out to achieve, but we are 90% of the way there. I will reopen a smaller issue in extended implementation to clean this up further.